### PR TITLE
chore(deps): bump redis version

### DIFF
--- a/redis-lua/Cargo.toml
+++ b/redis-lua/Cargo.toml
@@ -15,14 +15,13 @@ readme = "../README.md"
 serde = "1.0"
 rmp = "0.8"
 proc-macro-hack = "0.5"
-redis = "0.25"
+redis = "0.27"
 futures = "0.3"
-async-trait = "0.1"
 redis-lua-macro = { version = "=0.5.0", path = "../redis-lua-macro" }
 
 [dev-dependencies]
 rmp-serde = "1.3.0"
-redis = { version = "0.25", features = ["tokio-comp"] }
+redis = { version = "0.27", features = ["tokio-comp"] }
 tokio = { version = "1.37", features = ["full"] }
 
 [build-dependencies]


### PR DESCRIPTION
Update redis version to 0.27.  Also remove unneeded async-trait dependency.